### PR TITLE
metaタグのtitleとdescriptionの記述を修正

### DIFF
--- a/src/layouts/wiki/BaseLayout.astro
+++ b/src/layouts/wiki/BaseLayout.astro
@@ -8,7 +8,7 @@ const MAX_DESCRIPTION_LENGTH = 120 // Memo: 大まかにPCの120文字まで抑�
 const originUrl = Astro.url.origin
 const canonicalUrl = Astro.url.href
 const isChildPage = Astro.url.pathname.split('/').length > 2 ? true : false
-const pageTitle = `${title}${!isChildPage ? '' : ' | Product Design Wiki'}`
+const pageTitle = `${title}${isChildPage ? ' | Product Design Wiki' : ''}`
 const pageDescription = `${description.substring(0, MAX_DESCRIPTION_LENGTH)}${
   description.length > MAX_DESCRIPTION_LENGTH ? '...' : ''
 }`


### PR DESCRIPTION
* titleがTOPで`Product Design Wiki | Product Design Wiki`と表示されていた問題への対処
* optionalでdescriptionを入力していない場合、無限に文字が入るようになっていたので、120文字以内に収めるように変更
  * 120文字以上になった場合は省略し、「...」を表示するようにした 