### PR TITLE
トレイルスラッシュ対策の対応漏れ修正

### DIFF
--- a/src/pages/wiki/redirect/[title].astro
+++ b/src/pages/wiki/redirect/[title].astro
@@ -6,5 +6,5 @@ const filter = documents.filter((document) => {
   return document.frontmatter.title === title
 })
 
-return Astro.redirect(filter[0] ? `${filter[0].url}` : `/wiki/404`)
+return Astro.redirect(filter[0] ? `${filter[0].url}` : `/wiki/404/`)
 ---

--- a/src/plugins/replacePageLink.mjs
+++ b/src/plugins/replacePageLink.mjs
@@ -6,7 +6,7 @@ export default function replacePageLink() {
       let { value } = node
 
       if (/:\[(.+?)\]:/.test(value)) {
-        const replaceValue = value.replace(/:\[(.+?)\]:/g, '<a href="/wiki/redirect/$1">$1</a>')
+        const replaceValue = value.replace(/:\[(.+?)\]:/g, '<a href="/wiki/redirect/$1/">$1</a>')
 
         node.type = 'html'
         node.value = replaceValue


### PR DESCRIPTION
## やったこと

ページ内のリンク（リダイレクト処理）がトレイルスラッシュ（URL末尾に`/`を必ず付ける、付けないとエラーになる）対応に追従できてなかったので修正した

## 確認してほしいこと

preview URLを見てリダイレクトが正しく動いていること
https://product-design-hr6dr8d93-smarthr.vercel.app/wiki/
