### PR TITLE
🔧: renovate の自動マージ対象を minor に広げる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>kufu/renovate-config", ":automergePatch"],
+  "extends": ["local>kufu/renovate-config", ":automergeMinor"],
   "minor": {
     "groupName": "all dependencies"
   }


### PR DESCRIPTION
基本的にドキュメントサイトなので積極的に自動マージしてもらってよさそう。
ビルドの失敗は CI で気付けるので問題ないはず。