### PR TITLE
著作表記ができるようにする

### DIFF
--- a/src/layouts/wiki/ArticleLayout.astro
+++ b/src/layouts/wiki/ArticleLayout.astro
@@ -10,7 +10,7 @@ const description = content.description ? content.description : rawContent().sub
 // const editUrl = `https://github.com/kufu/product-design/blob/main/${content.file.substring(content.file.indexOf('src/', 1))}`
 ---
 
-<BaseLayout title={content.title} description={description}>
+<BaseLayout title={content.title} description={description} author={content.author}>
   <header slot="header">
     <a href="/wiki/">Product Design Wiki</a>
   </header>
@@ -20,6 +20,14 @@ const description = content.description ? content.description : rawContent().sub
         <h1>{content.title}</h1>
       </header>
       <slot />
+      {
+        content.author && (
+          <dl>
+            <dt>著者</dt>
+            <dd>{content.author}</dd>
+          </dl>
+        )
+      }
     </article>
     <!-- <p>
       <a href={editUrl}>ページを編集する</a>

--- a/src/layouts/wiki/BaseLayout.astro
+++ b/src/layouts/wiki/BaseLayout.astro
@@ -1,7 +1,7 @@
 ---
 import '../../css/wiki/style.css'
 
-const { title, description } = Astro.props
+const { title, description, author } = Astro.props
 
 const MAX_DESCRIPTION_LENGTH = 120 // Memo: 大まかにPCの120文字まで抑えるというルールに従っている
 
@@ -22,6 +22,7 @@ const pageDescription = `${description.substring(0, MAX_DESCRIPTION_LENGTH)}${
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="creator" content="株式会社SmartHR" />
     <meta name="description" content={pageDescription} />
+    {author && <meta name="author" content={author} />}
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={pageTitle} />

--- a/src/pages/wiki/documents/design-engineer.md
+++ b/src/pages/wiki/documents/design-engineer.md
@@ -2,7 +2,7 @@
 layout: ../../../layouts/wiki/ArticleLayout.astro
 title: デザインエンジニア
 description: 
-tag: idea,occupation
+tag: word,occupation
 ---
 
 この記事は準備中です。

--- a/src/pages/wiki/documents/design-engineering.md
+++ b/src/pages/wiki/documents/design-engineering.md
@@ -2,7 +2,8 @@
 layout: ../../../layouts/wiki/ArticleLayout.astro
 title: デザインエンジニアリング
 description: デザインエンジニアリングとは、デザインとエンジニアリングが交差する領域における課題解決の指針です。
-tag: idea,occupation
+tag: word,occupation
+author: Shinichi Kogiso
 ---
 
 デザインエンジニアリングとは、デザインとエンジニアリングが交差する領域において、プロダクトの目的と機能を合わせつつ素早くアイデアを検証・解決するための指針です。

--- a/src/pages/wiki/documents/design-system.md
+++ b/src/pages/wiki/documents/design-system.md
@@ -2,7 +2,7 @@
 layout: ../../../layouts/wiki/ArticleLayout.astro
 title: デザインシステム
 description:
-tag: word,UI
+tag: word,ui
 ---
 
 この記事は準備中です。


### PR DESCRIPTION
## 背景

- https://kufuinc.slack.com/archives/C017CMX7WGL/p1677489086405179
- コラムを書く際に組織ではなく、著作者を表記することで記事を書きやすくしたい（グループでなく、個人としての発信を許容する）

## やったこと

- markdownに`author`を入力できるようにした
  - authorがつかない場合はmetaタグにも用語・コラムにも著者表記は表示されない 
- metaタグにauthorを追加
- （ついでに）tagが間違っていて表記されていなかった記事のタグを修正（wordを付与）

## キャプチャ

![フッターの下に著者が表記されている](https://user-images.githubusercontent.com/4032232/221541088-fc70e215-5ee6-4ad8-b708-8264b721dd5b.png)
