### PR TITLE
🔧: CODEOWNERS に全員を指定する記述があると便利そう

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # https://help.github.com/en/articles/about-code-owners
 
+# すべてにプロデザを指定
 * @kufu/product-designer
+
+# コラムを含む Markdown に全員を指定
+*.md @oremega @ysasaki10 @ouji-miyahara @uknmr @versionfive @kgsi @daxelbook @wentzzz @ayumizu @drivesketch @tosiiu

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 ## Ignore files
 *.md
 *.mdx
+CODEOWNERS


### PR DESCRIPTION
コラムで誰が読んでて誰が読んでないかがパッと見えると少し楽になりそう。

### 余談

`wiki/documents` から `columns` を別ディレクトリにできるとレビュアーも別に指定できてよさそう。